### PR TITLE
fix(sdk): correct HumanityProvider wrapper + backend SDK init, with review of remaining issues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,8 +98,14 @@ HUMANITY_RPC_URL=https://rpc.humanity.org
 HUMANITY_CLIENT_ID=app_********************************
 HUMANITY_CLIENT_SECRET=sk_****************************************************************
 HUMANITY_REDIRECT_URI=http://localhost:5000/api/humanity/callback
+# SDK environment — must be one of: production | staging | testnet
+HUMANITY_ENVIRONMENT=testnet
 WPT_HUMAN_ADDRESS=0x0000000000000000000000000000000000000099
 MOCK_HUMANITY=false
+
+# Frontend (Vite) — must be exposed via VITE_ prefix to be readable in the browser
+VITE_HUMANITY_ENVIRONMENT=testnet
+VITE_HUMANITY_REDIRECT_URI=http://localhost:5000/login
 
 # Privy Wallet Abstraction
 VITE_PRIVY_APP_ID=your_privy_app_id_here

--- a/SDK_INTEGRATION_REVIEW.md
+++ b/SDK_INTEGRATION_REVIEW.md
@@ -1,0 +1,312 @@
+# Humanity Connect SDK integration review
+
+> **Status:** draft / guidance only — no code changes in this PR.
+> **Scope:** how `@humanity-org/connect-sdk` is wired up in `server/services/humanityProtocol.ts` and `server/routes/humanity.ts`.
+> **Theme:** _wrong context handed to the SDK_. Every painful bug below traces back to the SDK being given inputs it doesn't understand, then the integration silently masking the failure by granting verification anyway.
+
+This document is intentionally **a review, not a fix**. Each issue ends with a copy-pasteable prompt you can hand to your own coding AI to drive the change yourself. Apply them one at a time and verify against the SDK source before merging.
+
+---
+
+## TL;DR — the user-visible consequence
+
+Right now, in every realistic code path:
+
+- The SDK constructor **throws silently** (caught and swallowed, leaving `this.sdk = null`).
+- Even when it doesn't throw, the presets you request **do not exist** in the installed SDK version.
+- When preset verification errors, the integration falls through to:
+  ```ts
+  isVerified = true;
+  score = 85;
+  ```
+  in five separate places (`humanityProtocol.ts:110`, `:201`, `routes/humanity.ts:184`, `:202`, `:395`, `:412`).
+
+**Net effect: any user who completes the OAuth round-trip is treated as a verified human with a non-trivial score, regardless of whether they scanned a palm.** The biometric multiplier described in `ARCHITECTURE_OVERVIEW.md` § Phase 3 is not actually gated on biometric verification.
+
+That is the headline finding. The three sections below are the three reasons it happens.
+
+---
+
+## 1. `environment: 'sandbox'` is not a valid value (severity: critical)
+
+### Where
+`server/services/humanityProtocol.ts:53`
+
+```ts
+this.sdk = new HumanitySDK({
+  clientId: HUMANITY_CLIENT_ID,
+  clientSecret: HUMANITY_CLIENT_SECRET,
+  redirectUri: HUMANITY_REDIRECT_URI,
+  environment: 'sandbox', // ← not a known environment
+});
+```
+
+### Why it's wrong
+The SDK only registers three environments. From `connect-sdk/src/internal/environment.ts`:
+
+```ts
+export type EnvironmentName = 'production' | 'staging' | 'testnet';
+
+const DEFAULT_ENVIRONMENTS: Record<EnvironmentName, EnvironmentDescriptor> = {
+  production: { ... apiBaseUrl: 'https://api.humanity.org' ... },
+  staging:    { ... apiBaseUrl: 'https://api-staging.humanity.org' ... },
+  testnet:    { ... apiBaseUrl: 'https://api-testnet.humanity.org' ... },
+};
+```
+
+`EnvironmentRegistry.resolve()` throws `Unknown Humanity SDK environment "sandbox"` for anything else. That throw happens inside your `try { … } catch` block, so:
+
+- `this.sdk` stays `null`.
+- The startup log says `🔴 Failed to initialize Humanity SDK` — easy to miss in dev because the server boots fine.
+- Every endpoint then either bails with `"SDK not initialized"` or, in the `/login` and `/sync` routes, falls into the `isVerified = true; score = 85` fallback.
+
+### Why this is the root cause
+Once the SDK is `null`, **none of the other bugs below ever get exercised**. So fixing the env unblocks discovery of #2 and #3, which is also why this is listed first.
+
+### Acceptance criteria for the fix
+- The constructor must succeed with a value the SDK actually recognises (`testnet` for the dev grant build, per `ARCHITECTURE_OVERVIEW.md` § Technology Stack).
+- Boot log must show `🟢 Humanity SDK initialized successfully` in dev.
+- A failed init must hard-fail server startup, not be swallowed — see prompt below.
+
+### Prompt to hand to your AI
+
+```
+File: server/services/humanityProtocol.ts
+
+The HumanitySDK constructor is being called with environment: 'sandbox',
+but the @humanity-org/connect-sdk package only accepts
+'production' | 'staging' | 'testnet' (see node_modules/@humanity-org/connect-sdk
+/dist/internal/environment.* — DEFAULT_ENVIRONMENTS). Anything else throws
+"Unknown Humanity SDK environment …", and our try/catch silently swallows it,
+leaving this.sdk = null and forcing every downstream route into a
+"isVerified = true, score = 85" fallback that grants verification to
+unverified users.
+
+Please:
+
+1. Replace 'sandbox' with the value driven by an env var
+   HUMANITY_ENVIRONMENT (default 'testnet'). Add it to .env.example with
+   the comment "production | staging | testnet".
+2. Validate the value at startup. If it isn't one of the three, throw and
+   exit — do NOT silently continue with this.sdk = null.
+3. Remove the surrounding try/catch around `new HumanitySDK(...)` so init
+   failures crash the process. A misconfigured identity SDK must not boot
+   into a degraded "everyone is verified" state.
+4. Add a one-line console.log on success showing which environment is in
+   use, so this is visible in deploy logs.
+
+Do not touch any other file in this PR.
+```
+
+---
+
+## 2. Most of the presets being requested don't exist in this SDK version (severity: critical)
+
+### Where
+- `server/services/humanityProtocol.ts:104` (`['is_human', 'humanity_score']`)
+- `server/services/humanityProtocol.ts:183-195` (the eleven-preset list)
+- `server/routes/humanity.ts:174` and `:390` (`['is_human', 'humanity_score']`)
+
+### Why it's wrong
+The SDK's authoritative preset list lives in `connect-sdk/src/utils/ts-types/presets.ts:28`:
+
+```ts
+export type PresetName =
+  | 'is_human'
+  | 'is_18_plus'
+  | 'is_21_plus'
+  | 'is_accredited_investor'
+  | 'is_qualified_purchaser'
+  | 'is_institutional_investor'
+  | 'palm_verified'
+  | 'age_gate_alcohol'
+  | 'age_gate_gambling'
+  | 'investment_gate';
+```
+
+Of the presets the integration requests, only **`is_human`** is in this list. Every other preset — `humanity_score`, `social_accounts`, `email`, `google_connected`, `twitter_connected`, `facebook_connected`, `linkedin_connected`, `github_connected`, `discord_connected`, `telegram_connected` — is **rejected by the API** and lands in `PresetBatchResult.errors[]`.
+
+The README at the top of the npm package lists more presets (`humanity_score`, `email`, `social_accounts`, etc.). That README is **ahead of the actual code shipped in this SDK version** — it describes a future surface. Trust the type definitions, not the README.
+
+### How this combines with the fallback
+In `routes/humanity.ts:182-185`:
+
+```ts
+if (results?.errors && results.errors.length > 0) {
+    console.warn("🟡 [BACKEND] Presets returned errors (likely due to sandbox scope limits):", results.errors);
+    isVerified = true;
+    score = 85;
+}
+```
+
+So when the API returns errors for the nonexistent presets, you treat the user as verified at score 85. This is the actual production behaviour today, not just an edge case — it fires on every login because the preset list is wrong, not because of "sandbox scope limits". The comment is misdiagnosing the cause.
+
+### Acceptance criteria for the fix
+- Only request presets that exist in the SDK's `PresetName` union.
+- If a preset returns an error, **do not grant verification**. Either propagate the error to the caller or refuse the login.
+- The `humanityScore` field in the database must come from a real source. In this SDK version, there is no preset that returns a numeric score — derive it server-side from `palm_verified` + `is_human` (e.g. `palm_verified: true → 95`, `is_human: true → 60`, neither → reject), and write that policy down in code comments.
+
+### Prompt to hand to your AI
+
+```
+Files:
+  - server/services/humanityProtocol.ts
+  - server/routes/humanity.ts
+
+The integration calls sdk.verifyPresets({ presets: [...] }) with preset
+names that do not exist in @humanity-org/connect-sdk's PresetName union
+(see node_modules/@humanity-org/connect-sdk/dist/utils/ts-types/presets.*).
+The valid set in this SDK version is exactly:
+  is_human, is_18_plus, is_21_plus, is_accredited_investor,
+  is_qualified_purchaser, is_institutional_investor, palm_verified,
+  age_gate_alcohol, age_gate_gambling, investment_gate.
+
+The current code requests humanity_score, social_accounts, email, and a
+bunch of *_connected presets that simply do not exist. The API rejects
+them, the SDK puts the rejections into result.errors[], and our code then
+sets isVerified = true; score = 85, granting verification to unverified
+users.
+
+Please:
+
+1. Replace every verifyPresets call with: { presets: ['is_human', 'palm_verified'] }.
+2. Delete the preset names that don't exist (humanity_score, social_accounts,
+   email, *_connected) and any UI that depends on them — flag those UI
+   usages in the PR description for follow-up, do not leave dead reads.
+3. Compute humanityScore server-side from the two real presets, using this
+   policy (write it as a const ladder with a code comment explaining the
+   reasoning):
+       palm_verified === true → 95
+       is_human === true      → 60
+       neither                → 0  (and isVerified = false)
+4. If verifyPresets returns any entry in result.errors[], throw — do NOT
+   set isVerified = true. The current "score = 85 on errors" branch is
+   the security bug we are fixing.
+5. Add a TODO comment near the score ladder noting that when the SDK
+   exposes a real humanity_score preset, this should be replaced.
+
+Do not touch OAuth/state/CSRF code in this commit — that is a separate change.
+```
+
+---
+
+## 3. The response is parsed via three guessed fallback branches (severity: high)
+
+### Where
+`server/services/humanityProtocol.ts:107-136`, `:198-225`, `routes/humanity.ts:182-198`, `:393-409`.
+
+### Why it's wrong
+Each call site has the same shape:
+
+```ts
+if (results?.errors?.length > 0) {
+    isVerified = true; score = 85;          // ← branch A: insecure fallback
+} else if (results?.results && Array.isArray(results.results)) {
+    // ← branch B: tries result.preset === 'isHuman' || 'is_human',
+    //   reads result.credential.credentialSubject.is_human
+} else {
+    // ← branch C: reads results.is_human.verified
+    //   or results.is_human.credential.credentialSubject.is_human
+}
+```
+
+Branches B and C are guessing at three mutually exclusive shapes. The real shape is single and documented in `connect-sdk/src/adapters/presets.adapter.ts:8-32`:
+
+```ts
+export interface PresetCheckResult {
+  preset: DeveloperPresetKey;     // camelCase developer key, e.g. 'isHuman'
+  presetName: string;             // snake_case wire name, e.g. 'is_human'
+  scope: string;
+  value: boolean;                 // ← this is the answer
+  status: PresetStatus;           // 'active' | 'expired' | 'revoked' | 'pending'
+  expiresAt: string;
+  verifiedAt?: string;
+  evidence?: Record<string, unknown>;
+  rateLimit?: RateLimitInfo;
+}
+
+export interface PresetBatchResult {
+  results: PresetCheckResult[];
+  errors:  PresetErrorResult[];
+  raw:     PresetsVerifyResponse;
+  rateLimit?: RateLimitInfo;
+}
+```
+
+So:
+
+- There is no `result.verified` (your branch C reads it; it's always `undefined`).
+- There is no `result.credential.credentialSubject.is_human` (your branch B reads it; the SDK never exposes the raw VC payload at that path — only `evidence`).
+- `presetName` is `is_human` (snake), `preset` is `isHuman` (camel). Comparing both, as the code does, masks the fact that you don't know which one to use.
+
+This means even **after** fixing #1 and #2, the ladder you'd derive a score from would silently always read `undefined`, and you'd fall through to the same insecure fallback.
+
+### Acceptance criteria for the fix
+- Exactly one parsing branch.
+- Use the typed surface (`PresetBatchResult`, `PresetCheckResult`) — drop every `as any`.
+- Match by `presetName` (the wire name), since that is what `result.errors[]` also keys on.
+- Read the boolean from `.value`. There is no other place to read it from.
+
+### Prompt to hand to your AI
+
+```
+Files:
+  - server/services/humanityProtocol.ts
+  - server/routes/humanity.ts
+
+The four call sites that parse sdk.verifyPresets() responses currently
+have three "guessed" fallback branches, all using `as any`, none of which
+matches the real SDK type. The real shape is exported as
+PresetBatchResult / PresetCheckResult from
+@humanity-org/connect-sdk/dist/adapters/presets.adapter.d.ts:
+
+  PresetBatchResult  = { results: PresetCheckResult[]; errors: PresetErrorResult[]; raw; rateLimit?; }
+  PresetCheckResult  = { preset; presetName; scope; value: boolean; status; expiresAt; verifiedAt?; evidence?; rateLimit?; }
+
+There is no `verified` field. There is no `credential.credentialSubject.*`
+field. The boolean answer lives at `result.value`.
+
+Please:
+
+1. Import the types from @humanity-org/connect-sdk at the top of each file
+   and remove every `as any` cast on the verifyPresets result.
+2. Replace the three-branch parser at every call site with a single
+   typed read:
+       const byName = new Map(results.results.map(r => [r.presetName, r]));
+       const isHuman      = byName.get('is_human')?.value === true;
+       const palmVerified = byName.get('palm_verified')?.value === true;
+   And refuse the request if `results.errors.length > 0`.
+3. Also assert `r.status === 'active'` before treating r.value as truthy —
+   PresetStatus can be 'expired' | 'revoked' | 'pending', and the README
+   error code E4010 specifically calls out 24-hour expiry.
+4. Delete the `humanityScore` parsing entirely (the preset doesn't exist
+   in this SDK version — see review section #2).
+
+Do not touch OAuth/state code in this commit.
+```
+
+---
+
+## Secondary findings (out of scope for "context", but worth a follow-up PR)
+
+These are real bugs, but they're not in the "wrong context handed to the SDK" theme. Listing them so they don't get lost:
+
+- **State is not a CSRF token, it's a userId payload.** `humanityProtocol.ts:71-73` packs `userId` into a base64-encoded JSON blob and sends it as `state`. That conflates two concerns: routing the callback (server-side) and CSRF defence (random nonce, single-use). Generate state with `HumanitySDK.generateState()`, store it server-side keyed by session, and validate with `HumanitySDK.verifyState()` on the callback. Keep the userId mapping separate.
+- **State is passed via `additionalQueryParams`**, not the typed `state` field on `buildAuthUrl`. It happens to work because `additionalQueryParams.state` overwrites the URL param, but it's a footgun — the next SDK version could disallow overriding reserved OAuth params.
+- **Missing `nonce`.** `buildAuthUrl` accepts a `nonce` for ID-token replay protection. Not generated, not validated.
+- **`codeVerifier` is returned to the frontend** (`routes/humanity.ts:88`). The SDK's own README explicitly says "PKCE code verifier should be stored in a server session, not client storage". Move it to a session/cookie keyed by state.
+- **`/api/humanity/login` accepts a frontend-supplied `humanityId`** (`routes/humanity.ts:153`) and uses it as the unique key for `creators.humanityCredentialId` (`routes/humanity.ts:281`). A malicious client can claim any humanityId and inherit another user's `creators` row. Derive the unique identifier from the `accessToken` server-side via the SDK, never from the request body.
+- **Two parallel verification stacks** (`@humanity-org/connect-sdk` _and_ `@humanity-org/react-sdk`) both write `creators.isHumanityVerified`. Pick one source of truth; the other becomes a UI shell.
+
+Each of these deserves its own PR after the three core context bugs are fixed.
+
+---
+
+## Suggested rollout order
+
+1. **PR 1 — environment.** Section #1 above. Smallest possible diff. Verifies in deploy logs that the SDK is actually initialising.
+2. **PR 2 — preset names + response shape.** Sections #2 and #3 together; they're the same code paths and reviewing them separately doubles the work. Land behind a feature flag if you want to ship cautiously.
+3. **PR 3 — OAuth state / CSRF / PKCE storage.** Secondary findings list, top three bullets.
+4. **PR 4 — humanityId trust boundary.** Secondary list, fourth bullet. This one is also a security issue and shouldn't wait too long.
+
+Until at least PR 1 + PR 2 land, the biometric multiplier in `WPTHumanRewards.sol` is multiplying rewards by a number that does not reflect biometric reality.

--- a/SDK_INTEGRATION_REVIEW.md
+++ b/SDK_INTEGRATION_REVIEW.md
@@ -1,114 +1,206 @@
-# Humanity Connect SDK integration review
+# Humanity SDK integration review
 
-> **Status:** draft / guidance only — no code changes in this PR.
-> **Scope:** how `@humanity-org/connect-sdk` is wired up in `server/services/humanityProtocol.ts` and `server/routes/humanity.ts`.
-> **Theme:** _wrong context handed to the SDK_. Every painful bug below traces back to the SDK being given inputs it doesn't understand, then the integration silently masking the failure by granting verification anyway.
-
-This document is intentionally **a review, not a fix**. Each issue ends with a copy-pasteable prompt you can hand to your own coding AI to drive the change yourself. Apply them one at a time and verify against the SDK source before merging.
+> **What this PR contains:** two minimal "starter" code fixes that unblock everything else, plus written guidance for the rest. Each remaining issue ships with a `prompt`-tagged code block you can paste into your own AI assistant.
+>
+> **Scope of code changes in this PR:**
+>
+> - `client/src/App.tsx` — `<HumanityProvider>` wrapper now configured correctly.
+> - `server/services/humanityProtocol.ts` — backend SDK initialised correctly, no longer silently swallowed.
+> - `.env.example` — adds the env vars the two fixes above need.
+>
+> **Everything else in this document is guidance, not code.** The intent is to surface the issues clearly enough that you can drive the remaining fixes with your own coding AI, rather than have a stranger's patches dropped into your repo.
 
 ---
 
-## TL;DR — the user-visible consequence
+## TL;DR — the user-visible bug this is fixing
 
-Right now, in every realistic code path:
+Today, in every realistic code path:
 
-- The SDK constructor **throws silently** (caught and swallowed, leaving `this.sdk = null`).
-- Even when it doesn't throw, the presets you request **do not exist** in the installed SDK version.
-- When preset verification errors, the integration falls through to:
+- The `HumanitySDK` constructor in `humanityProtocol.ts` throws on `environment: 'sandbox'` (only `'production' | 'staging' | 'testnet'` are valid).
+- The throw is swallowed by a `try/catch`, leaving `this.sdk = null`.
+- Every route then falls through to a hardcoded fallback:
   ```ts
   isVerified = true;
   score = 85;
   ```
-  in five separate places (`humanityProtocol.ts:110`, `:201`, `routes/humanity.ts:184`, `:202`, `:395`, `:412`).
+  which appears in five places: `humanityProtocol.ts:110`, `:201`, `routes/humanity.ts:184`, `:202`, `:395`, `:412`.
+- On the client, `<HumanityProvider environment="sandbox" ...>` in `App.tsx:99-103` triggers the same exception inside `useMemo`, so the React Provider is broken too — which is why login tends to hang or no-op.
 
 **Net effect: any user who completes the OAuth round-trip is treated as a verified human with a non-trivial score, regardless of whether they scanned a palm.** The biometric multiplier described in `ARCHITECTURE_OVERVIEW.md` § Phase 3 is not actually gated on biometric verification.
 
-That is the headline finding. The three sections below are the three reasons it happens.
+The two fixes in this PR don't fully close that hole, but they make it possible to *see* the hole — which is the prerequisite for closing it.
 
 ---
 
-## 1. `environment: 'sandbox'` is not a valid value (severity: critical)
+## What's fixed in this PR (1) — the React `<HumanityProvider>` wrapper
 
 ### Where
-`server/services/humanityProtocol.ts:53`
+`client/src/App.tsx` lines 99-103.
+
+### Before
+
+```tsx
+<HumanityProvider
+  clientId={import.meta.env.VITE_HUMANITY_CLIENT_ID || 'app_…'}
+  redirectUri={'http://localhost:5000/login'}
+  environment="sandbox"
+>
+```
+
+### After
+
+```tsx
+<HumanityProvider
+  clientId={import.meta.env.VITE_HUMANITY_CLIENT_ID || 'app_…'}
+  redirectUri={import.meta.env.VITE_HUMANITY_REDIRECT_URI ?? 'http://localhost:5000/login'}
+  environment={(import.meta.env.VITE_HUMANITY_ENVIRONMENT ?? 'testnet') as 'production' | 'staging' | 'testnet'}
+  storage="localStorage"
+>
+```
+
+### Why each prop changed
+
+- **`environment`** — `"sandbox"` is not a registered name. The connect-sdk only knows `production | staging | testnet` (`connect-sdk/src/internal/environment.ts`). The react-sdk's `mapEnvironmentToSdk` is identity (`(env) => env`), so the bad string passes straight through and the underlying SDK throws inside `useMemo` → Provider tree breaks.
+- **`redirectUri`** — was hardcoded to localhost, breaking any non-local deploy. Now driven from `VITE_HUMANITY_REDIRECT_URI` so prod/staging configs can pin their own callback URL.
+- **`storage`** — defaulted to `'memory'`, meaning the access token vanishes on every page refresh. `useHumanity().getAccessToken()` then returns `null`, the `/api/humanity/sync` call silently sends `accessToken: null`, and the user appears to be logged in (because of the `localStorage` workaround in `Login.tsx:97`) while having no usable token. `'localStorage'` persists the actual token, not just metadata.
+
+### What this **does not** fix
+
+- The `scopes: ['openid']` problem in `Login.tsx:31` and `HumanityStatus.tsx:142` (see "Pending #1" below).
+- The `humanity_score` references in `<HumanityProfile showFields={...} />` (see "Pending #4").
+
+These are intentionally left for you to fix yourself — see prompts further down.
+
+---
+
+## What's fixed in this PR (2) — one correct backend SDK init
+
+### Where
+`server/services/humanityProtocol.ts` lines 46-62.
+
+### Before
 
 ```ts
-this.sdk = new HumanitySDK({
-  clientId: HUMANITY_CLIENT_ID,
-  clientSecret: HUMANITY_CLIENT_SECRET,
-  redirectUri: HUMANITY_REDIRECT_URI,
-  environment: 'sandbox', // ← not a known environment
-});
+if (HUMANITY_CLIENT_ID && HUMANITY_CLIENT_SECRET) {
+  try {
+    this.sdk = new HumanitySDK({
+      clientId: HUMANITY_CLIENT_ID,
+      clientSecret: HUMANITY_CLIENT_SECRET,
+      redirectUri: HUMANITY_REDIRECT_URI,
+      environment: 'sandbox',
+    });
+    console.log("🟢 Humanity SDK initialized successfully in Sandbox mode");
+  } catch (err) {
+    console.error("🔴 Failed to initialize Humanity SDK:", err);
+  }
+}
 ```
+
+### After
+
+```ts
+if (HUMANITY_CLIENT_ID && HUMANITY_CLIENT_SECRET) {
+  const env = (process.env.HUMANITY_ENVIRONMENT ?? 'testnet') as 'production' | 'staging' | 'testnet';
+  this.sdk = new HumanitySDK({
+    clientId: HUMANITY_CLIENT_ID,
+    clientSecret: HUMANITY_CLIENT_SECRET,
+    redirectUri: HUMANITY_REDIRECT_URI,
+    environment: env,
+  });
+  console.log(`🟢 Humanity SDK initialized in ${env} mode`);
+}
+```
+
+### Why both changes matter
+
+1. **`environment: 'sandbox'` → env-driven `'testnet'` default.** Same root cause as the client wrapper.
+2. **`try/catch` removed.** This is the bigger change. With the catch in place, a misconfigured identity SDK boots into a degraded state where every route sees `this.sdk === null` and falls through to `isVerified = true; score = 85`. **A misconfigured identity SDK must crash on boot, not silently grant verification.** Removing the catch makes that invariant a hard failure instead of a silent one.
+
+### What this **does not** fix
+
+- The five `isVerified = true; score = 85` fallbacks themselves. They no longer fire from `this.sdk === null`, but they *will* fire the moment a real preset call returns errors. Closing them is "Pending #2" below.
+- The wrong preset names being requested (`humanity_score`, `social_accounts`, `email`, `*_connected`) — "Pending #2" below.
+- The 3-branch `as any` parser at every preset response site — "Pending #3" below.
+
+---
+
+## Pending #1 — frontend scopes don't match backend preset reads (severity: critical)
+
+### Where
+- `client/src/pages/Login.tsx:31` — `humanityLogin({ mode: 'redirect', scopes: ['openid'] })`
+- `client/src/components/creators/HumanityStatus.tsx:142` — `<HumanityConnect scopes={['openid']} ... />`
+- `client/src/components/creators/CreatorPortal.tsx` — same pattern
 
 ### Why it's wrong
-The SDK only registers three environments. From `connect-sdk/src/internal/environment.ts`:
+
+In this SDK, **a preset _is_ a scope**. To call `verifyPresets({ presets: ['is_human'] })` server-side, the access token must have been issued with the `is_human` scope at OAuth time. The mapping is in `connect-sdk/src/utils/ts-types/presets.ts`:
 
 ```ts
-export type EnvironmentName = 'production' | 'staging' | 'testnet';
-
-const DEFAULT_ENVIRONMENTS: Record<EnvironmentName, EnvironmentDescriptor> = {
-  production: { ... apiBaseUrl: 'https://api.humanity.org' ... },
-  staging:    { ... apiBaseUrl: 'https://api-staging.humanity.org' ... },
-  testnet:    { ... apiBaseUrl: 'https://api-testnet.humanity.org' ... },
-};
+export enum PresetScope {
+  IS_HUMAN      = 'hp:presets.is_human',
+  PALM_VERIFIED = 'hp:presets.palm_verified',
+  IS_18_PLUS    = 'hp:presets.is_18_plus',
+  // …
+}
 ```
 
-`EnvironmentRegistry.resolve()` throws `Unknown Humanity SDK environment "sandbox"` for anything else. That throw happens inside your `try { … } catch` block, so:
+Right now you request `['openid']` only, then the backend tries to read `is_human` and `humanity_score` with that token. The API returns `E4003` (forbidden — insufficient scope) for every preset, the SDK puts those into `result.errors[]`, and your code does:
 
-- `this.sdk` stays `null`.
-- The startup log says `🔴 Failed to initialize Humanity SDK` — easy to miss in dev because the server boots fine.
-- Every endpoint then either bails with `"SDK not initialized"` or, in the `/login` and `/sync` routes, falls into the `isVerified = true; score = 85` fallback.
-
-### Why this is the root cause
-Once the SDK is `null`, **none of the other bugs below ever get exercised**. So fixing the env unblocks discovery of #2 and #3, which is also why this is listed first.
-
-### Acceptance criteria for the fix
-- The constructor must succeed with a value the SDK actually recognises (`testnet` for the dev grant build, per `ARCHITECTURE_OVERVIEW.md` § Technology Stack).
-- Boot log must show `🟢 Humanity SDK initialized successfully` in dev.
-- A failed init must hard-fail server startup, not be swallowed — see prompt below.
-
-### Prompt to hand to your AI
-
+```ts
+if (results?.errors?.length > 0) {
+  isVerified = true;
+  score = 85;     // ← unverified user is now "verified"
+}
 ```
-File: server/services/humanityProtocol.ts
 
-The HumanitySDK constructor is being called with environment: 'sandbox',
-but the @humanity-org/connect-sdk package only accepts
-'production' | 'staging' | 'testnet' (see node_modules/@humanity-org/connect-sdk
-/dist/internal/environment.* — DEFAULT_ENVIRONMENTS). Anything else throws
-"Unknown Humanity SDK environment …", and our try/catch silently swallows it,
-leaving this.sdk = null and forcing every downstream route into a
-"isVerified = true, score = 85" fallback that grants verification to
+This means every login currently grants verification, regardless of palm-scan state, **on every fresh OAuth round-trip** — not just edge cases.
+
+### Prompt to fix with AI
+
+```prompt
+Files:
+  - client/src/pages/Login.tsx (around line 28-34)
+  - client/src/components/creators/HumanityStatus.tsx (around line 142)
+  - client/src/components/creators/CreatorPortal.tsx (any HumanityConnect / humanityLogin call)
+
+The frontend currently calls humanityLogin / HumanityConnect with
+scopes: ['openid'], but the backend then tries to read presets like
+is_human and palm_verified using the resulting access token. In the
+@humanity-org/connect-sdk preset model, "preset" and "scope" are the
+same thing — to read is_human server-side, the token must have been
+issued with the is_human scope at OAuth time. With only 'openid', every
+verifyPresets call returns E4003 errors that our backend then swallows
+into "isVerified = true; score = 85", granting verification to
 unverified users.
 
 Please:
 
-1. Replace 'sandbox' with the value driven by an env var
-   HUMANITY_ENVIRONMENT (default 'testnet'). Add it to .env.example with
-   the comment "production | staging | testnet".
-2. Validate the value at startup. If it isn't one of the three, throw and
-   exit — do NOT silently continue with this.sdk = null.
-3. Remove the surrounding try/catch around `new HumanitySDK(...)` so init
-   failures crash the process. A misconfigured identity SDK must not boot
-   into a degraded "everyone is verified" state.
-4. Add a one-line console.log on success showing which environment is in
-   use, so this is visible in deploy logs.
+1. Replace every occurrence of scopes: ['openid'] with
+   scopes: ['openid', 'is_human', 'palm_verified'].
+2. Do NOT add scopes that don't exist in this SDK version. The valid
+   preset list is: is_human, is_18_plus, is_21_plus,
+   is_accredited_investor, is_qualified_purchaser,
+   is_institutional_investor, palm_verified, age_gate_alcohol,
+   age_gate_gambling, investment_gate. (See
+   node_modules/@humanity-org/connect-sdk/dist/utils/ts-types/presets.*)
+3. Add a const SCOPES = ['openid', 'is_human', 'palm_verified'] at the
+   top of Login.tsx and reuse it everywhere, so the set is defined once.
 
-Do not touch any other file in this PR.
+Do not touch the backend in this commit.
 ```
 
 ---
 
-## 2. Most of the presets being requested don't exist in this SDK version (severity: critical)
+## Pending #2 — backend requests presets that don't exist in this SDK version (severity: critical)
 
 ### Where
-- `server/services/humanityProtocol.ts:104` (`['is_human', 'humanity_score']`)
-- `server/services/humanityProtocol.ts:183-195` (the eleven-preset list)
-- `server/routes/humanity.ts:174` and `:390` (`['is_human', 'humanity_score']`)
+- `server/services/humanityProtocol.ts:104` — `['is_human', 'humanity_score']`
+- `server/services/humanityProtocol.ts:183-195` — eleven-preset list including `google_connected`, `email`, `social_accounts`, etc.
+- `server/routes/humanity.ts:174` and `:390` — `['is_human', 'humanity_score']`
 
 ### Why it's wrong
-The SDK's authoritative preset list lives in `connect-sdk/src/utils/ts-types/presets.ts:28`:
+
+The SDK's authoritative preset list (`connect-sdk/src/utils/ts-types/presets.ts:14-26`):
 
 ```ts
 export type PresetName =
@@ -124,189 +216,285 @@ export type PresetName =
   | 'investment_gate';
 ```
 
-Of the presets the integration requests, only **`is_human`** is in this list. Every other preset — `humanity_score`, `social_accounts`, `email`, `google_connected`, `twitter_connected`, `facebook_connected`, `linkedin_connected`, `github_connected`, `discord_connected`, `telegram_connected` — is **rejected by the API** and lands in `PresetBatchResult.errors[]`.
+Of the presets your code requests, **only `is_human`** exists. `humanity_score`, `social_accounts`, `email`, and the seven `*_connected` presets are not in this SDK version. The API rejects each one, lands them in `result.errors[]`, and the same insecure fallback fires.
 
-The README at the top of the npm package lists more presets (`humanity_score`, `email`, `social_accounts`, etc.). That README is **ahead of the actual code shipped in this SDK version** — it describes a future surface. Trust the type definitions, not the README.
+The npm-published README lists these other presets — but the README is *ahead of the code shipped in this SDK version*. **Trust the type definitions, not the README.**
 
-### How this combines with the fallback
-In `routes/humanity.ts:182-185`:
+### Prompt to fix with AI
 
-```ts
-if (results?.errors && results.errors.length > 0) {
-    console.warn("🟡 [BACKEND] Presets returned errors (likely due to sandbox scope limits):", results.errors);
-    isVerified = true;
-    score = 85;
-}
-```
-
-So when the API returns errors for the nonexistent presets, you treat the user as verified at score 85. This is the actual production behaviour today, not just an edge case — it fires on every login because the preset list is wrong, not because of "sandbox scope limits". The comment is misdiagnosing the cause.
-
-### Acceptance criteria for the fix
-- Only request presets that exist in the SDK's `PresetName` union.
-- If a preset returns an error, **do not grant verification**. Either propagate the error to the caller or refuse the login.
-- The `humanityScore` field in the database must come from a real source. In this SDK version, there is no preset that returns a numeric score — derive it server-side from `palm_verified` + `is_human` (e.g. `palm_verified: true → 95`, `is_human: true → 60`, neither → reject), and write that policy down in code comments.
-
-### Prompt to hand to your AI
-
-```
+```prompt
 Files:
   - server/services/humanityProtocol.ts
   - server/routes/humanity.ts
 
-The integration calls sdk.verifyPresets({ presets: [...] }) with preset
-names that do not exist in @humanity-org/connect-sdk's PresetName union
-(see node_modules/@humanity-org/connect-sdk/dist/utils/ts-types/presets.*).
-The valid set in this SDK version is exactly:
+Every sdk.verifyPresets() call requests preset names that are not in the
+PresetName union of @humanity-org/connect-sdk. The valid set in this
+SDK version is exactly:
   is_human, is_18_plus, is_21_plus, is_accredited_investor,
   is_qualified_purchaser, is_institutional_investor, palm_verified,
   age_gate_alcohol, age_gate_gambling, investment_gate.
 
-The current code requests humanity_score, social_accounts, email, and a
-bunch of *_connected presets that simply do not exist. The API rejects
-them, the SDK puts the rejections into result.errors[], and our code then
-sets isVerified = true; score = 85, granting verification to unverified
+The current code requests humanity_score, social_accounts, email, and
+several *_connected presets that simply do not exist. The API rejects
+them, the SDK puts them into result.errors[], and our code then sets
+isVerified = true; score = 85, granting verification to unverified
 users.
 
 Please:
 
-1. Replace every verifyPresets call with: { presets: ['is_human', 'palm_verified'] }.
-2. Delete the preset names that don't exist (humanity_score, social_accounts,
-   email, *_connected) and any UI that depends on them — flag those UI
-   usages in the PR description for follow-up, do not leave dead reads.
-3. Compute humanityScore server-side from the two real presets, using this
-   policy (write it as a const ladder with a code comment explaining the
-   reasoning):
+1. Replace every verifyPresets call argument with:
+       { presets: ['is_human', 'palm_verified'] }
+2. Delete code paths that read humanity_score, social_accounts, email,
+   *_connected — they will always be undefined. List the deleted UI
+   reads in the PR description so they don't silently rot.
+3. Compute humanityScore server-side from the two real presets, with
+   this policy (write it as a const ladder with a comment explaining
+   why these thresholds):
        palm_verified === true → 95
        is_human === true      → 60
        neither                → 0  (and isVerified = false)
-4. If verifyPresets returns any entry in result.errors[], throw — do NOT
-   set isVerified = true. The current "score = 85 on errors" branch is
-   the security bug we are fixing.
+4. If verifyPresets returns ANY entry in result.errors[], throw — do
+   NOT set isVerified = true. The "score = 85 on errors" branch is the
+   security bug we are closing here.
 5. Add a TODO comment near the score ladder noting that when the SDK
    exposes a real humanity_score preset, this should be replaced.
 
-Do not touch OAuth/state/CSRF code in this commit — that is a separate change.
+Do not touch OAuth/state/CSRF code in this commit.
 ```
 
 ---
 
-## 3. The response is parsed via three guessed fallback branches (severity: high)
+## Pending #3 — preset response parsed via 3 guessed `as any` branches (severity: high)
 
 ### Where
-`server/services/humanityProtocol.ts:107-136`, `:198-225`, `routes/humanity.ts:182-198`, `:393-409`.
+`humanityProtocol.ts:107-136`, `:198-225`, `routes/humanity.ts:182-198`, `:393-409`.
 
 ### Why it's wrong
-Each call site has the same shape:
+
+Every call site has the same shape:
 
 ```ts
 if (results?.errors?.length > 0) {
-    isVerified = true; score = 85;          // ← branch A: insecure fallback
+    isVerified = true; score = 85;          // branch A: insecure fallback
 } else if (results?.results && Array.isArray(results.results)) {
-    // ← branch B: tries result.preset === 'isHuman' || 'is_human',
-    //   reads result.credential.credentialSubject.is_human
+    // branch B: tries result.preset === 'isHuman' || 'is_human'
+    //           reads result.credential.credentialSubject.is_human
 } else {
-    // ← branch C: reads results.is_human.verified
-    //   or results.is_human.credential.credentialSubject.is_human
+    // branch C: reads results.is_human.verified
+    //           or results.is_human.credential.credentialSubject.is_human
 }
 ```
 
-Branches B and C are guessing at three mutually exclusive shapes. The real shape is single and documented in `connect-sdk/src/adapters/presets.adapter.ts:8-32`:
+Branches B and C are guessing at three mutually exclusive shapes, none of which match the SDK's actual response. The real shape, from `connect-sdk/src/adapters/presets.adapter.ts:8-32`:
 
 ```ts
 export interface PresetCheckResult {
   preset: DeveloperPresetKey;     // camelCase developer key, e.g. 'isHuman'
   presetName: string;             // snake_case wire name, e.g. 'is_human'
   scope: string;
-  value: boolean;                 // ← this is the answer
+  value: boolean;                 // ← the actual answer
   status: PresetStatus;           // 'active' | 'expired' | 'revoked' | 'pending'
   expiresAt: string;
   verifiedAt?: string;
   evidence?: Record<string, unknown>;
-  rateLimit?: RateLimitInfo;
 }
 
 export interface PresetBatchResult {
   results: PresetCheckResult[];
   errors:  PresetErrorResult[];
   raw:     PresetsVerifyResponse;
-  rateLimit?: RateLimitInfo;
 }
 ```
 
 So:
+- There is no `result.verified` (branch C reads it; always `undefined`).
+- There is no `result.credential.credentialSubject.is_human` (branch B reads it; the SDK never exposes the raw VC at that path — only `evidence`).
+- Even after pending #1 and #2 land, branches B and C would still read `undefined`, fall through to the defaults, and re-trigger the "verified by default" bug.
 
-- There is no `result.verified` (your branch C reads it; it's always `undefined`).
-- There is no `result.credential.credentialSubject.is_human` (your branch B reads it; the SDK never exposes the raw VC payload at that path — only `evidence`).
-- `presetName` is `is_human` (snake), `preset` is `isHuman` (camel). Comparing both, as the code does, masks the fact that you don't know which one to use.
+### Prompt to fix with AI
 
-This means even **after** fixing #1 and #2, the ladder you'd derive a score from would silently always read `undefined`, and you'd fall through to the same insecure fallback.
-
-### Acceptance criteria for the fix
-- Exactly one parsing branch.
-- Use the typed surface (`PresetBatchResult`, `PresetCheckResult`) — drop every `as any`.
-- Match by `presetName` (the wire name), since that is what `result.errors[]` also keys on.
-- Read the boolean from `.value`. There is no other place to read it from.
-
-### Prompt to hand to your AI
-
-```
+```prompt
 Files:
   - server/services/humanityProtocol.ts
   - server/routes/humanity.ts
 
-The four call sites that parse sdk.verifyPresets() responses currently
-have three "guessed" fallback branches, all using `as any`, none of which
-matches the real SDK type. The real shape is exported as
-PresetBatchResult / PresetCheckResult from
+The four call sites that parse sdk.verifyPresets() responses use three
+"guessed" fallback branches, all using `as any`, none matching the real
+SDK type. The real shape is exported as PresetBatchResult /
+PresetCheckResult from
 @humanity-org/connect-sdk/dist/adapters/presets.adapter.d.ts:
 
-  PresetBatchResult  = { results: PresetCheckResult[]; errors: PresetErrorResult[]; raw; rateLimit?; }
-  PresetCheckResult  = { preset; presetName; scope; value: boolean; status; expiresAt; verifiedAt?; evidence?; rateLimit?; }
+  PresetBatchResult = {
+    results: PresetCheckResult[];
+    errors:  PresetErrorResult[];
+    raw; rateLimit?;
+  }
+  PresetCheckResult = {
+    preset; presetName; scope;
+    value: boolean;       // ← read from here
+    status;               // ← 'active' | 'expired' | 'revoked' | 'pending'
+    expiresAt; verifiedAt?; evidence?; rateLimit?;
+  }
 
 There is no `verified` field. There is no `credential.credentialSubject.*`
-field. The boolean answer lives at `result.value`.
+path. The boolean answer lives at `result.value`.
 
 Please:
 
-1. Import the types from @humanity-org/connect-sdk at the top of each file
-   and remove every `as any` cast on the verifyPresets result.
+1. Import PresetBatchResult and PresetCheckResult from
+   @humanity-org/connect-sdk at the top of each file. Remove every
+   `as any` cast on verifyPresets results.
 2. Replace the three-branch parser at every call site with a single
    typed read:
        const byName = new Map(results.results.map(r => [r.presetName, r]));
        const isHuman      = byName.get('is_human')?.value === true;
        const palmVerified = byName.get('palm_verified')?.value === true;
-   And refuse the request if `results.errors.length > 0`.
-3. Also assert `r.status === 'active'` before treating r.value as truthy —
-   PresetStatus can be 'expired' | 'revoked' | 'pending', and the README
+   Refuse the request if results.errors.length > 0.
+3. Also assert r.status === 'active' before treating r.value as truthy.
+   PresetStatus can be 'expired' | 'revoked' | 'pending', and
    error code E4010 specifically calls out 24-hour expiry.
-4. Delete the `humanityScore` parsing entirely (the preset doesn't exist
-   in this SDK version — see review section #2).
+4. Delete every read of humanityScore from the response — it does not
+   exist as a preset in this SDK version (see Pending #2).
 
 Do not touch OAuth/state code in this commit.
 ```
 
 ---
 
-## Secondary findings (out of scope for "context", but worth a follow-up PR)
+## Pending #4 — `<HumanityProfile>` reads a field that doesn't exist (severity: low)
 
-These are real bugs, but they're not in the "wrong context handed to the SDK" theme. Listing them so they don't get lost:
+### Where
+`client/src/components/creators/HumanityStatus.tsx:101`
 
-- **State is not a CSRF token, it's a userId payload.** `humanityProtocol.ts:71-73` packs `userId` into a base64-encoded JSON blob and sends it as `state`. That conflates two concerns: routing the callback (server-side) and CSRF defence (random nonce, single-use). Generate state with `HumanitySDK.generateState()`, store it server-side keyed by session, and validate with `HumanitySDK.verifyState()` on the callback. Keep the userId mapping separate.
-- **State is passed via `additionalQueryParams`**, not the typed `state` field on `buildAuthUrl`. It happens to work because `additionalQueryParams.state` overwrites the URL param, but it's a footgun — the next SDK version could disallow overriding reserved OAuth params.
-- **Missing `nonce`.** `buildAuthUrl` accepts a `nonce` for ID-token replay protection. Not generated, not validated.
-- **`codeVerifier` is returned to the frontend** (`routes/humanity.ts:88`). The SDK's own README explicitly says "PKCE code verifier should be stored in a server session, not client storage". Move it to a session/cookie keyed by state.
-- **`/api/humanity/login` accepts a frontend-supplied `humanityId`** (`routes/humanity.ts:153`) and uses it as the unique key for `creators.humanityCredentialId` (`routes/humanity.ts:281`). A malicious client can claim any humanityId and inherit another user's `creators` row. Derive the unique identifier from the `accessToken` server-side via the SDK, never from the request body.
-- **Two parallel verification stacks** (`@humanity-org/connect-sdk` _and_ `@humanity-org/react-sdk`) both write `creators.isHumanityVerified`. Pick one source of truth; the other becomes a UI shell.
+```tsx
+<HumanityProfile variant="card" showFields={['name', 'humanity_score']} showAvatar={true} showBadges={true} />
+```
 
-Each of these deserves its own PR after the three core context bugs are fixed.
+### Why it's wrong
+
+`humanity_score` is not a real preset in this SDK version (Pending #2). `HumanityProfile` will render the field empty / undefined. Cosmetic, but misleading — it suggests there's a humanity_score being returned when there isn't.
+
+### Prompt to fix with AI
+
+```prompt
+File: client/src/components/creators/HumanityStatus.tsx around line 101
+
+The <HumanityProfile> component is rendering a humanity_score field
+that doesn't exist as a preset in the installed @humanity-org/connect-sdk
+version. The valid presets in this SDK are listed in
+node_modules/@humanity-org/connect-sdk/dist/utils/ts-types/presets.* —
+humanity_score is not among them.
+
+Please:
+
+1. Remove 'humanity_score' from showFields. Use ['name'] for now.
+2. Render the score from the backend response (status.score from
+   useQuery(['humanity-status', creatorId])) in a sibling element
+   instead — that's a server-derived score, not a real preset, so
+   showing it as one is misleading.
+3. Add a code comment noting why we don't use HumanityProfile for the
+   score: "Score is computed server-side from is_human + palm_verified
+   presets (see server/services/humanityProtocol.ts), not returned by
+   the SDK as a single preset."
+
+No backend changes.
+```
+
+---
+
+## Pending #5 — secondary OAuth/state findings (severity: medium, follow-up PR)
+
+These are real bugs but separate from the "wrong context" theme. Each gets one prompt block.
+
+### 5a. State is a userId payload, not a CSRF token
+
+`humanityProtocol.ts:71-73` packs userId into a base64 JSON blob and sends it as `state`. That conflates routing-the-callback with CSRF defence.
+
+```prompt
+File: server/services/humanityProtocol.ts (getAuthUrl) and server/routes/humanity.ts (callback)
+
+State is currently being used as a userId payload (base64-encoded JSON
+with userId inside). That conflates two separate concerns:
+  - routing the callback to the right user (server-side concern)
+  - CSRF defence (random nonce, single-use, validated)
+
+The SDK provides HumanitySDK.generateState() and HumanitySDK.verifyState()
+specifically for the CSRF concern. Please:
+
+1. Generate state with HumanitySDK.generateState() in getAuthUrl.
+2. Server-side, store a row keyed by state with: { userId, codeVerifier,
+   createdAt, used: false }. Use a short TTL (5 minutes) and mark used
+   after the first callback consumes it.
+3. In the callback handler, look up state in that store, validate with
+   HumanitySDK.verifyState(stored, received), then read userId from the
+   stored row — never from the state value itself.
+4. Pass state via the typed `state` field of buildAuthUrl, NOT via
+   additionalQueryParams.state. The latter works today by coincidence
+   and would break if the SDK starts disallowing reserved-param overrides.
+
+Add a brief comment explaining the new flow above getAuthUrl.
+```
+
+### 5b. PKCE codeVerifier returned to the frontend
+
+`routes/humanity.ts:88` returns the codeVerifier in the auth-url response. The SDK's own README says: *"The PKCE code verifier should be stored in a server session, not client storage."*
+
+```prompt
+File: server/routes/humanity.ts (the GET /api/humanity/auth-url/:userId handler)
+
+Right now we return the PKCE codeVerifier to the frontend so the
+frontend can pass it back during the callback. This is wrong — the
+SDK README explicitly says codeVerifier must stay server-side.
+
+Please:
+
+1. Stop returning codeVerifier in the auth-url response.
+2. Store codeVerifier server-side in the same store you set up for
+   state (Pending #5a's prompt). Key both by state.
+3. In the callback handler, look up { userId, codeVerifier } by state
+   and pass codeVerifier to sdk.exchangeCodeForToken from the stored
+   row. The frontend never sees it.
+
+This depends on the state store from #5a, so do them in the same PR.
+```
+
+### 5c. Frontend-supplied `humanityId` is trusted as a unique key
+
+`routes/humanity.ts:153` accepts `humanityId` from the request body and uses it at line 281 as the unique key for `creators.humanityCredentialId`. A malicious client can claim any humanityId and inherit another user's `creators` row.
+
+```prompt
+File: server/routes/humanity.ts (POST /api/humanity/login handler)
+
+The handler accepts humanityId from the request body and uses it as
+the unique key when looking up or creating a `creators` row. This is
+a trust-boundary bug — a malicious client can claim any humanityId
+and take over another user's creator account.
+
+Please:
+
+1. Remove humanityId from the request body schema entirely.
+2. Derive the unique identifier from the access token server-side. The
+   connect-sdk does not expose userinfo directly, but the token's
+   `sub` claim (or the result of /v2/userinfo if you call it via the
+   SDK's connection) contains an opaque, app-scoped subject ID that's
+   safe to use as the creators.humanityCredentialId.
+3. Add a server-side assertion: if the derived ID differs from any
+   value the frontend tries to send, reject the request with 400.
+
+This is a security bug — please prioritise it after Pending #1, #2, #3.
+```
 
 ---
 
 ## Suggested rollout order
 
-1. **PR 1 — environment.** Section #1 above. Smallest possible diff. Verifies in deploy logs that the SDK is actually initialising.
-2. **PR 2 — preset names + response shape.** Sections #2 and #3 together; they're the same code paths and reviewing them separately doubles the work. Land behind a feature flag if you want to ship cautiously.
-3. **PR 3 — OAuth state / CSRF / PKCE storage.** Secondary findings list, top three bullets.
-4. **PR 4 — humanityId trust boundary.** Secondary list, fourth bullet. This one is also a security issue and shouldn't wait too long.
+| Order | Issue                                | Why this order                                                                                         |
+|-------|--------------------------------------|--------------------------------------------------------------------------------------------------------|
+| 0     | **This PR** — Provider + init wedge  | Without these, none of the other fixes are even reachable.                                              |
+| 1     | Pending #1 (frontend scopes)          | Smallest possible follow-up. Fixes the "every login grants verification" bug at the source.            |
+| 2     | Pending #2 + #3 (preset names + parser shape) | These are the same code paths; reviewing them separately is double work. Land behind a feature flag if you want to ship cautiously. |
+| 3     | Pending #5a + #5b (state + PKCE)      | Same store, same PR.                                                                                   |
+| 4     | Pending #5c (humanityId trust boundary) | Security bug. Should not wait long after #2.                                                          |
+| 5     | Pending #4 (HumanityProfile cosmetic) | Pure cleanup — do anytime after #2.                                                                    |
 
-Until at least PR 1 + PR 2 land, the biometric multiplier in `WPTHumanRewards.sol` is multiplying rewards by a number that does not reflect biometric reality.
+Until at least items 1, 2, 3 land, the biometric multiplier in `WPTHumanRewards.sol` is multiplying rewards by a number that does not reflect biometric reality.

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -96,10 +96,11 @@ function App() {
         }
       }}
     >
-      <HumanityProvider 
-        clientId={import.meta.env.VITE_HUMANITY_CLIENT_ID || 'app_8ba7aeecf21f28ba51601f5073573f0e'} 
-        redirectUri={'http://localhost:5000/login'}
-        environment="sandbox"
+      <HumanityProvider
+        clientId={import.meta.env.VITE_HUMANITY_CLIENT_ID || 'app_8ba7aeecf21f28ba51601f5073573f0e'}
+        redirectUri={import.meta.env.VITE_HUMANITY_REDIRECT_URI ?? 'http://localhost:5000/login'}
+        environment={(import.meta.env.VITE_HUMANITY_ENVIRONMENT ?? 'testnet') as 'production' | 'staging' | 'testnet'}
+        storage="localStorage"
       >
         <QueryClientProvider client={queryClient}>
           <TooltipProvider>

--- a/server/services/humanityProtocol.ts
+++ b/server/services/humanityProtocol.ts
@@ -43,21 +43,22 @@ export class HumanityProtocolService {
     this.provider = new ethers.providers.JsonRpcProvider(HUMANITY_RPC_URL);
     this.contract = new ethers.Contract(WPT_HUMAN_ADDRESS, WPT_HUMAN_ABI, this.provider);
     
-    // Initialize the official SDK
+    // Initialize the official SDK.
+    // NOTE: do NOT wrap this in try/catch. A misconfigured identity SDK must
+    // crash on boot — silently leaving this.sdk = null is what causes every
+    // route to fall through to the "isVerified = true; score = 85" fallback
+    // and grant verification to users who never completed it.
     if (HUMANITY_CLIENT_ID && HUMANITY_CLIENT_SECRET) {
-      try {
-        this.sdk = new HumanitySDK({
-          clientId: HUMANITY_CLIENT_ID,
-          clientSecret: HUMANITY_CLIENT_SECRET, // We are a confidential backend client
-          redirectUri: HUMANITY_REDIRECT_URI,
-          environment: 'sandbox', // Use sandbox to match frontend configuration
-        });
-        console.log("🟢 Humanity SDK initialized successfully in Sandbox mode");
-      } catch (err) {
-        console.error("🔴 Failed to initialize Humanity SDK:", err);
-      }
+      const env = (process.env.HUMANITY_ENVIRONMENT ?? 'testnet') as 'production' | 'staging' | 'testnet';
+      this.sdk = new HumanitySDK({
+        clientId: HUMANITY_CLIENT_ID,
+        clientSecret: HUMANITY_CLIENT_SECRET, // confidential backend client
+        redirectUri: HUMANITY_REDIRECT_URI,
+        environment: env,
+      });
+      console.log(`🟢 Humanity SDK initialized in ${env} mode`);
     } else {
-        console.warn("🟡 Humanity SDK not initialized: Missing CLIENT_ID or CLIENT_SECRET");
+      console.warn("🟡 Humanity SDK not initialized: Missing CLIENT_ID or CLIENT_SECRET");
     }
   }
 


### PR DESCRIPTION
## What this PR does

Two minimal **code fixes** that unblock the rest of the integration, plus a written **review** (`SDK_INTEGRATION_REVIEW.md`) of what's still wrong — each remaining issue ships with a copy-paste prompt you can hand to your own coding AI.

### Code fixes (small, scoped, independently reviewable)

- **`client/src/App.tsx`** — `<HumanityProvider>` wrapper now configured correctly:
  - `environment="sandbox"` → env-driven `'testnet'` default. The connect-sdk only registers `production | staging | testnet`; `'sandbox'` was throwing inside `useMemo`, breaking the React provider tree.
  - `redirectUri` now reads from `VITE_HUMANITY_REDIRECT_URI` instead of hardcoded `localhost:5000`, so non-local deploys actually work.
  - `storage="localStorage"` added. Default is `'memory'`, which means access tokens vanish on every page refresh — the manual `localStorage.setItem('webpayback_session', …)` workaround in `Login.tsx:97` only persists session metadata, not the actual token.
- **`server/services/humanityProtocol.ts`** — backend SDK now initialises correctly:
  - `environment: 'sandbox'` → env-driven `'testnet'` default.
  - **Removed the `try/catch` around `new HumanitySDK(...)`.** With the catch in place, a misconfigured identity SDK boots into a degraded state where `this.sdk === null` and every route silently falls through to `isVerified = true; score = 85`, granting verification to unverified users. A misconfigured identity SDK must crash on boot, not silently grant access.
- **`.env.example`** — adds `HUMANITY_ENVIRONMENT`, `VITE_HUMANITY_ENVIRONMENT`, `VITE_HUMANITY_REDIRECT_URI`.

### What's NOT fixed (intentional — see [`SDK_INTEGRATION_REVIEW.md`](../blob/sdk-integration-review/SDK_INTEGRATION_REVIEW.md))

The doc has five pending issues, each with its own ` ```prompt ` block ready to paste into Claude / ChatGPT / Cursor / Copilot:

| #     | Severity | Topic                                                                             |
| ----- | -------- | --------------------------------------------------------------------------------- |
| **1** | critical | Frontend `scopes: ['openid']` doesn't grant access to the presets the backend reads — every login currently grants verification because of this. |
| **2** | critical | Backend requests presets that don't exist in this SDK version (`humanity_score`, `social_accounts`, `email`, `*_connected`). Errors get swallowed by the `score = 85` fallback. |
| **3** | high     | `verifyPresets` response parsed via three guessed `as any` branches; none matches the real `PresetCheckResult` shape. |
| **4** | low      | `<HumanityProfile showFields={[..., 'humanity_score']}>` reads a non-existent preset field. |
| **5** | medium   | OAuth state used as userId payload (not CSRF), PKCE codeVerifier returned to frontend, frontend-supplied `humanityId` trusted as unique key. |

## TL;DR — the user-visible bug today

In every realistic code path:

1. `HumanitySDK` constructor throws on `'sandbox'`.
2. The throw is caught and swallowed → `this.sdk = null`.
3. Every route falls through to `isVerified = true; score = 85`.
4. Frontend `<HumanityProvider environment="sandbox">` triggers the same exception inside `useMemo`, so the React provider is broken too.

**Net effect: anyone who completes the OAuth round-trip is treated as a verified human with a non-trivial score, regardless of whether they ever scanned a palm.** The biometric multiplier in `WPTHumanRewards.sol` is multiplying rewards by a number that doesn't reflect biometric reality.

This PR doesn't fully close that hole — but it makes the hole *visible* (init no longer silent, Provider no longer crashing on render), which is the prerequisite for fixing it.

## Suggested rollout order

| Order | Issue                                          | Why this order                                                                                 |
| ----- | ---------------------------------------------- | ---------------------------------------------------------------------------------------------- |
| 0     | **This PR** — Provider + init wedge            | Without these, none of the other fixes are reachable.                                          |
| 1     | Pending #1 (frontend scopes)                   | Smallest possible follow-up. Fixes "every login grants verification" at the source.            |
| 2     | Pending #2 + #3 (preset names + parser shape)  | Same code paths — reviewing separately is double work. Land behind a feature flag if cautious. |
| 3     | Pending #5a + #5b (state + PKCE)               | Same server-side store, same PR.                                                               |
| 4     | Pending #5c (humanityId trust boundary)        | Security bug — don't let it sit long after #2.                                                 |
| 5     | Pending #4 (HumanityProfile cosmetic)          | Pure cleanup, do anytime after #2.                                                             |

## Disclosure

Posted from a fork of this repo. Prepared with assistance from Claude (Anthropic). All claims about SDK behaviour are anchored to specific files in `@humanity-org/connect-sdk` and `@humanity-org/react-sdk` — please verify the citations against your installed versions before acting. The two committed code changes are intentionally minimal; review them as you would any other small PR, run the app once with the new env vars set, and confirm you see `🟢 Humanity SDK initialized in testnet mode` in the server logs and a working OAuth round-trip on the client.